### PR TITLE
Preventing NullPointer exception on empty ResultSet

### DIFF
--- a/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInput.java
+++ b/src/org/pentaho/di/trans/steps/cassandrainput/CassandraInput.java
@@ -96,12 +96,18 @@ public class CassandraInput extends BaseStep implements StepInterface {
             do {
                 Object[] outputRow = new Object[this.rowColumns.length];
                 Row row = rs.one();
+
+                if (rs.isExhausted()) {
+                    logDetailed("ResultSet exhausted, no rows returned.");
+                    break;
+                }
+
                 incrementLinesInput();
                 rowCount++;
 
                 String[] arrayOfString;
                 int j = (arrayOfString = this.rowColumns).length;
-                
+
                 ColumnDefinitions cd = row.getColumnDefinitions();
 
                 for (int i = 0; i < j; i++) {


### PR DESCRIPTION
Preventing NullPointer exception on getting the row when the ResultSet is empty. Check if ResultSet is exhausted at the top of the loop.